### PR TITLE
Only unhide the window, do not make it key.

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -33,7 +33,7 @@
 	cenaImage.center = cenaWindow.center;
 	cenaWindow.backgroundColor = [UIColor clearColor];
 	cenaImage = [[UIImageView alloc] initWithImage:[UIImage imageWithContentsOfFile:@"/Library/Application Support/Superslam/cena.png"]];
-	[cenaWindow makeKeyAndVisible];
+	cenaWindow.hidden = NO;
 	[cenaWindow addSubview: cenaImage];	
 	[cenaWindow addGestureRecognizer:tap];
 }


### PR DESCRIPTION
Making the window key (and not setting the key window back to what it was afterwards) breaks the keyboard, which only responds to the key window. As there is no text input here, we can simply unhide the window, which is all that's needed for it to appear.
